### PR TITLE
Feature/disable auto installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ services:
 rvm:
 - 2.2.4
 before_install:
-- gem install bundler -v 1.10.6
-install: bundle _1.10.6_ install
+- gem install bundler -v 1.12.5
+install: bundle _1.12.5_ install
 script:
-- bundle _1.10.6_ exec rake
-- bundle _1.10.6_ exec rake build
+- bundle _1.12.5_ exec rake
+- bundle _1.12.5_ exec rake build
 deploy:
   provider: rubygems
   skip_cleanup: true

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 group :development do
   gem 'vagrant',
       git: 'git://github.com/mitchellh/vagrant.git',
-      ref: 'v1.8.1'
+      ref: 'v1.8.4'
 
   gem 'byebug'
   gem 'mocha'

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Once we're happy with the functionality and mechanics, this will be expanded to 
 
 ## Usage
 
-When used with Landrush, it will automatically be activated and install itself.
-
-Without Landrush, one has to enable it explicitly via `landrush_ip.override` if auto-installation is desired.
+When `landrush_ip_get` is called, the necessary binary will automatically be installed. Alternatively, one can explicitly force automatic installation `landrush_ip.auto_install` if desired.
 
 Other plugins can use the provided capabilities to check if it is installed and/or install it.
 
@@ -73,7 +71,7 @@ By default, it returns the output in TSV (Tab Separated Values) format.
 The JSON and YAML formats output objects and hashes respectively, that have a `name`, `ipv4` and `ipv6` key.
 
 No filtering is done with any of the formats, so any interface that has no assigned IP will still show up.
- It's left up to consumer to filter that out.
+ It's left up to consumers to filter that out.
  Same goes for the order in which they are returned, they are returned as returned by the OS.
  
 The following examples are all from OS X (Darwin)

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.libs << 'test'
 
-  #TODO: Don't do this?
+  # TODO: Don't do this?
   t.warning = false
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,9 @@ Bundler::GemHelper.install_tasks
 Rake::TestTask.new do |t|
   t.pattern = 'test/**/*_test.rb'
   t.libs << 'test'
+
+  #TODO: Don't do this?
+  t.warning = false
 end
 
 # Cucumber acceptance test task

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ const Version string = "#{LandrushIp::VERSION}"
 
   File.write('util/version.go', go_version)
 
-  sh 'docker pull golang:1.6'
+  sh 'docker pull golang:1.7'
   sh 'docker run --rm -v $(pwd)/util:/usr/src/landrush-ip -w /usr/src/landrush-ip golang:1.6 make'
 end
 

--- a/features/landrush-ip-linux.feature
+++ b/features/landrush-ip-linux.feature
@@ -12,7 +12,7 @@ Feature: landrush-ip-linux
 
       config.vm.synced_folder '.', '/vagrant', disabled: true
 
-      config.landrush_ip.override = true
+      config.landrush_ip.auto_install = true
     end
     """
     When I successfully run `bundle exec vagrant up --provider <provider>`

--- a/features/landrush-ip-windows.feature
+++ b/features/landrush-ip-windows.feature
@@ -16,7 +16,7 @@ Feature: landrush-ip-linux
 
       config.vm.synced_folder '.', '/vagrant', disabled: true
 
-      config.landrush_ip.override = true
+      config.landrush_ip.auto_install = true
     end
     """
     When I successfully run `bundle exec vagrant up --provider <provider>`

--- a/lib/landrush-ip/action/install.rb
+++ b/lib/landrush-ip/action/install.rb
@@ -11,12 +11,8 @@ module LandrushIp
         @machine.guest.capability(:landrush_ip_installed)
       end
 
-      def override?
-        @machine.config.landrush_ip.override
-      end
-
-      def enabled?
-        override? || (@machine.config.key('landrush') && @machine.config.landrush.enabled)
+      def auto_install?
+        @machine.config.landrush_ip.auto_install
       end
 
       def install
@@ -31,11 +27,11 @@ module LandrushIp
         @machine = env[:machine]
 
         # Auto install in one of 2 cases:
-        # - landrush-ip is forcibly enabled via the override setting
+        # - landrush-ip is forcibly enabled via the auto_install setting
         # - Landrush is installed and enabled
-        install if enabled? && !installed?
+        install if auto_install? && !installed?
 
-        @env[:ui].info I18n.t('vagrant.config.landrush_ip.not_enabled') unless enabled?
+        @env[:ui].info I18n.t('vagrant.config.landrush_ip.not_enabled') unless auto_install?
       end
     end
   end

--- a/lib/landrush-ip/cap/linux/landrush_ip_get.rb
+++ b/lib/landrush-ip/cap/linux/landrush_ip_get.rb
@@ -6,6 +6,8 @@ module LandrushIp
     module Linux
       module LandrushIpGet
         def self.landrush_ip_get(machine)
+          machine.guest.capability(:landrush_ip_install) unless machine.guest.capability(:landrush_ip_installed)
+
           result = ''
           machine.communicate.execute(command) do |type, data|
             result << data if type == :stdout

--- a/lib/landrush-ip/cap/windows/landrush_ip_get.rb
+++ b/lib/landrush-ip/cap/windows/landrush_ip_get.rb
@@ -6,6 +6,8 @@ module LandrushIp
     module Windows
       module LandrushIpGet
         def self.landrush_ip_get(machine)
+          machine.guest.capability(:landrush_ip_install) unless machine.guest.capability(:landrush_ip_installed)
+
           result = ''
           machine.communicate.execute(command) do |type, data|
             result << data if type == :stdout

--- a/lib/landrush-ip/config.rb
+++ b/lib/landrush-ip/config.rb
@@ -24,7 +24,7 @@ module LandrushIp
 
     def auto_install?
       # Keeping override for backward compatibility
-      @auto_install || @override
+      @auto_install || @override == true
     end
 
     def finalize!

--- a/lib/landrush-ip/config.rb
+++ b/lib/landrush-ip/config.rb
@@ -14,7 +14,7 @@ module LandrushIp
     def initialize
       @override = UNSET_VALUE
       @auto_install = UNSET_VALUE
-      @logger   = Log4r::Logger.new('vagrantplugins::landruship::config')
+      @logger = Log4r::Logger.new('vagrantplugins::landruship::config')
     end
 
     def default_options(new_values = {})

--- a/lib/landrush-ip/config.rb
+++ b/lib/landrush-ip/config.rb
@@ -5,27 +5,42 @@ require 'vagrant/util/template_renderer'
 module LandrushIp
   class Config < Vagrant.plugin('2', :config)
     attr_accessor :override
+    attr_accessor :auto_install
 
     DEFAULTS = {
-      override: false
+      auto_install: false
     }.freeze
 
     def initialize
       @override = UNSET_VALUE
+      @auto_install = UNSET_VALUE
       @logger   = Log4r::Logger.new('vagrantplugins::landruship::config')
     end
 
     def default_options(new_values = {})
-      @default_options = {} if @default_options == UNSET_VALUE
+      @default_options = DEFAULTS if @default_options == UNSET_VALUE
       @default_options.merge! new_values
     end
 
-    def override?
-      @override
+    def auto_install?
+      # Keeping override for backward compatibility
+      @auto_install || @override
     end
 
     def finalize!
-      @default_options = {} if @default_options == UNSET_VALUE
+      DEFAULTS.each do |name, value|
+        if instance_variable_get('@' + name.to_s) == UNSET_VALUE
+          instance_variable_set '@' + name.to_s, value
+        end
+      end
+    end
+
+    def validate(machine)
+      if @override != UNSET_VALUE
+        machine.env.ui.warn I18n.t('vagrant.config.landrush_ip.not_enabled')
+      end
+
+      nil
     end
   end
 end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,8 +2,10 @@ en:
   vagrant:
     config:
       landrush_ip:
-        not_enabled: "Landrush IP override not enabled and Landrush was not found, nothing to do."
+        not_enabled: "Automatic installation for Landrush IP not enabled"
         not_installed: "Landrush IP not installed in guest yet (or it's an outdated version). Installing now."
+        warnings:
+          override: "landrush_ip.override is deprecated and will be removed in the next major version. Please use landrush_ip.auto_install instead."
         errors:
           unsupported_arch: "Unsupported architecture"
           cannot_install: "Unable to install landrush-ip"

--- a/test/landrush-ip/cap/linux/landrush_ip_get_test.rb
+++ b/test/landrush-ip/cap/linux/landrush_ip_get_test.rb
@@ -9,7 +9,6 @@ module LandrushIp
           let(:machine) { mock_machine }
 
           it 'should return a hash' do
-            machine.communicate.stub_command(LandrushIp::Cap::Linux::LandrushIpGet.command, mock_output)
             machine.guest.capability(:landrush_ip_get).must_equal mock_data
           end
         end

--- a/test/landrush-ip/config_test.rb
+++ b/test/landrush-ip/config_test.rb
@@ -5,9 +5,9 @@ describe 'LandrushIp::Config' do
     machine = mock_machine
     config  = machine.config.landrush_ip
 
-    machine.config.landrush_ip.override = true
-    config.override?.must_equal true
-    machine.config.landrush_ip.override = false
-    config.override?.must_equal false
+    machine.config.landrush_ip.auto_install = true
+    config.auto_install?.must_equal true
+    machine.config.landrush_ip.auto_install = false
+    config.auto_install?.must_equal false
   end
 end

--- a/test/mock/communicator.rb
+++ b/test/mock/communicator.rb
@@ -11,8 +11,7 @@ module Mock
       responses[command] = response
     end
 
-    def sudo(command)
-      puts "SUDO: #{command}"
+    def sudo(command, opts=nil)
       commands[:sudo] << command
       responses[command]
     end
@@ -26,6 +25,10 @@ module Mock
 
     def test(command)
       commands[:test] << command
+      true
+    end
+
+    def upload(source, dest)
       true
     end
 

--- a/test/mock/communicator.rb
+++ b/test/mock/communicator.rb
@@ -11,7 +11,7 @@ module Mock
       responses[command] = response
     end
 
-    def sudo(command, opts=nil)
+    def sudo(command, _opts = nil)
       commands[:sudo] << command
       responses[command]
     end
@@ -28,7 +28,7 @@ module Mock
       true
     end
 
-    def upload(source, dest)
+    def upload(_source, _dest)
       true
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,6 +51,12 @@ def mock_machine(options = {})
   )
 
   machine.instance_variable_set('@communicator', Mock::Communicator.new)
+
+  # Default Linux stubs
+  machine.communicate.stub_command('uname -mrs', 'Linux 3.16.0-4-amd64 x86_64')
+  machine.communicate.stub_command(LandrushIp::Cap::Linux::LandrushIpInstalled.command, '')
+  machine.communicate.stub_command(LandrushIp::Cap::Linux::LandrushIpGet.command, mock_output)
+
   machine
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,12 +52,15 @@ def mock_machine(options = {})
 
   machine.instance_variable_set('@communicator', Mock::Communicator.new)
 
-  # Default Linux stubs
+  mock_machine_defaults_linux machine
+
+  machine
+end
+
+def mock_machine_defaults_linux(machine)
   machine.communicate.stub_command('uname -mrs', 'Linux 3.16.0-4-amd64 x86_64')
   machine.communicate.stub_command(LandrushIp::Cap::Linux::LandrushIpInstalled.command, '')
   machine.communicate.stub_command(LandrushIp::Cap::Linux::LandrushIpGet.command, mock_output)
-
-  machine
 end
 
 module MiniTest


### PR DESCRIPTION
Fixes #3 by changing the logic behind installation. Rather than auto-installing as soon as Landrush is detected, we now install when explicitly configured to do so, or when landrush_ip_get is called.
