### PR TITLE
Add Arm64 support

### DIFF
--- a/lib/landrush-ip/cap/linux/landrush_ip_install.rb
+++ b/lib/landrush-ip/cap/linux/landrush_ip_install.rb
@@ -9,6 +9,8 @@ module LandrushIp
             'landrush-ip-linux_amd64'
           elsif uname =~ /(arm)/i
             'landrush-ip-linux_arm'
+          elsif uname =~ /(aarch64)/i
+            'landrush-ip-linux_arm64'
           elsif uname =~ /(i386|i686)/i
             'landrush-ip-linux_386'
           else

--- a/lib/landrush-ip/version.rb
+++ b/lib/landrush-ip/version.rb
@@ -1,3 +1,3 @@
 module LandrushIp
-  VERSION = '0.2.5'.freeze
+  VERSION = '0.2.6'.freeze
 end

--- a/util/Makefile
+++ b/util/Makefile
@@ -11,6 +11,7 @@ GOOSARCH = darwin_386 \
 	darwin_amd64 \
 	linux_386 \
 	linux_amd64 \
+	linux_arm64 \
 	windows_386 \
 	windows_amd64
 
@@ -22,6 +23,7 @@ linux_%: export GOOS=linux
 
 %_386: export GOARCH=386
 %_amd64: export GOARCH=amd64
+%_arm64: export GOARCH=arm64
 
 # Phony targets
 .PHONY: all deps clean $(GOOSARCH)
@@ -33,7 +35,7 @@ build: clean deps
 		-rebuild \
 		-ldflags="-s" \
 		-os "linux windows" \
-		-arch "386 arm amd64"
+		-arch "386 arm64 amd64"
 
 deps:
 	go get github.com/mitchellh/gox

--- a/util/Makefile
+++ b/util/Makefile
@@ -35,7 +35,7 @@ build: clean deps
 		-rebuild \
 		-ldflags="-s" \
 		-os "linux windows" \
-		-arch "386 arm64 amd64"
+		-arch "386 arm arm64 amd64"
 
 deps:
 	go get github.com/mitchellh/gox


### PR DESCRIPTION
Adds a `linux_arm64` build for `aarch64` architectures like the M1 Macbook Pro.